### PR TITLE
Cosmetic Fix: Broken logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # optipfair
 
 <div align="center">
-  <img src="images/optipfair.png" alt="optipfair Logo" width="600"/>
+  <img src="images/optiPfair.png" alt="optipfair Logo" width="600"/>
 </div>
 
 <div align="center">


### PR DESCRIPTION
On the Readme file the OptiPFair logo appeared broken due to case sensitivity. The reference to the image file in the readme was fixed. No other changes were made.